### PR TITLE
Add bun-based todo example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# golang-orm-bun
+# Todo list with Bun
+
+This is a simple todo list project demonstrating a hexagonal architecture in Go.
+It uses the [Bun](https://bun.uptrace.dev/) ORM with SQLite.
+
+Run the server:
+
+```bash
+go run ./cmd/todo
+```
+
+The HTTP API exposes CRUD endpoints under `/todos`.

--- a/cmd/todo/main.go
+++ b/cmd/todo/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"database/sql"
+	"log"
+	"net/http"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+	"github.com/uptrace/bun/extra/bundebug"
+
+	"github.com/example/todo/internal/domain"
+	httpapi "github.com/example/todo/internal/http"
+	"github.com/example/todo/internal/infra/sqlite"
+	"github.com/example/todo/internal/service"
+)
+
+func main() {
+	sqldb, err := sql.Open(sqliteshim.ShimName, "file:todos.db?cache=shared&_foreign_keys=on")
+	if err != nil {
+		log.Fatalf("open db: %v", err)
+	}
+	defer sqldb.Close()
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
+
+	if _, err := db.NewCreateTable().Model((*domain.Todo)(nil)).IfNotExists().Exec(nil); err != nil {
+		log.Fatalf("create table: %v", err)
+	}
+
+	repo := sqlite.NewTodoRepository(db)
+	svc := service.NewTodoService(repo)
+	handler := httpapi.NewHandler(svc)
+
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	log.Println("listening on :8080")
+	if err := http.ListenAndServe(":8080", mux); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/todo
+
+go 1.23.8

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -1,0 +1,5 @@
+package domain
+
+import "errors"
+
+var ErrNotFound = errors.New("todo not found")

--- a/internal/domain/todo.go
+++ b/internal/domain/todo.go
@@ -1,0 +1,20 @@
+package domain
+
+import "time"
+
+// Todo represents a task item.
+type Todo struct {
+	ID        int64     `bun:",pk,autoincrement" json:"id"`
+	Title     string    `json:"title"`
+	Completed bool      `json:"completed"`
+	CreatedAt time.Time `bun:",nullzero,notnull,default:current_timestamp" json:"created_at"`
+}
+
+// TodoRepository defines data access methods for Todo.
+type TodoRepository interface {
+	Create(todo *Todo) error
+	Get(id int64) (*Todo, error)
+	List() ([]*Todo, error)
+	Update(todo *Todo) error
+	Delete(id int64) error
+}

--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -1,0 +1,93 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/example/todo/internal/domain"
+	"github.com/example/todo/internal/service"
+)
+
+// Handler exposes HTTP routes for todo service.
+type Handler struct {
+	Service *service.TodoService
+}
+
+// NewHandler creates an HTTP handler.
+func NewHandler(s *service.TodoService) *Handler {
+	return &Handler{Service: s}
+}
+
+func (h *Handler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/todos", h.handleTodos)
+	mux.HandleFunc("/todos/", h.handleTodo)
+}
+
+func (h *Handler) handleTodos(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		todos, err := h.Service.List()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		respondJSON(w, todos)
+	case http.MethodPost:
+		var todo domain.Todo
+		if err := json.NewDecoder(r.Body).Decode(&todo); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := h.Service.Create(&todo); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		respondJSON(w, todo)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (h *Handler) handleTodo(w http.ResponseWriter, r *http.Request) {
+	idStr := r.URL.Path[len("/todos/"):]
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		todo, err := h.Service.Get(id)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		respondJSON(w, todo)
+	case http.MethodPut:
+		var todo domain.Todo
+		if err := json.NewDecoder(r.Body).Decode(&todo); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		todo.ID = id
+		if err := h.Service.Update(&todo); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		respondJSON(w, todo)
+	case http.MethodDelete:
+		if err := h.Service.Delete(id); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func respondJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(v)
+}

--- a/internal/infra/sqlite/todo_repository.go
+++ b/internal/infra/sqlite/todo_repository.go
@@ -1,0 +1,49 @@
+package sqlite
+
+import (
+	"context"
+
+	"github.com/uptrace/bun"
+
+	"github.com/example/todo/internal/domain"
+)
+
+// TodoRepository implements domain.TodoRepository using Bun and SQLite.
+type TodoRepository struct {
+	DB *bun.DB
+}
+
+// NewTodoRepository creates a TodoRepository.
+func NewTodoRepository(db *bun.DB) *TodoRepository {
+	return &TodoRepository{DB: db}
+}
+
+func (r *TodoRepository) Create(todo *domain.Todo) error {
+	_, err := r.DB.NewInsert().Model(todo).Exec(context.Background())
+	return err
+}
+
+func (r *TodoRepository) Get(id int64) (*domain.Todo, error) {
+	todo := new(domain.Todo)
+	err := r.DB.NewSelect().Model(todo).Where("id = ?", id).Scan(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return todo, nil
+}
+
+func (r *TodoRepository) List() ([]*domain.Todo, error) {
+	var todos []*domain.Todo
+	err := r.DB.NewSelect().Model(&todos).Order("id").Scan(context.Background())
+	return todos, err
+}
+
+func (r *TodoRepository) Update(todo *domain.Todo) error {
+	_, err := r.DB.NewUpdate().Model(todo).WherePK().Exec(context.Background())
+	return err
+}
+
+func (r *TodoRepository) Delete(id int64) error {
+	_, err := r.DB.NewDelete().Model((*domain.Todo)(nil)).Where("id = ?", id).Exec(context.Background())
+	return err
+}

--- a/internal/repository/memory.go
+++ b/internal/repository/memory.go
@@ -1,0 +1,49 @@
+package repository
+
+import "github.com/example/todo/internal/domain"
+
+// MemoryRepository is an in-memory implementation of TodoRepository.
+type MemoryRepository struct {
+	data   map[int64]*domain.Todo
+	nextID int64
+}
+
+// NewMemoryRepository creates a MemoryRepository.
+func NewMemoryRepository() *MemoryRepository {
+	return &MemoryRepository{data: make(map[int64]*domain.Todo), nextID: 1}
+}
+
+func (m *MemoryRepository) Create(todo *domain.Todo) error {
+	todo.ID = m.nextID
+	m.nextID++
+	m.data[todo.ID] = todo
+	return nil
+}
+
+func (m *MemoryRepository) Get(id int64) (*domain.Todo, error) {
+	if todo, ok := m.data[id]; ok {
+		return todo, nil
+	}
+	return nil, domain.ErrNotFound
+}
+
+func (m *MemoryRepository) List() ([]*domain.Todo, error) {
+	todos := make([]*domain.Todo, 0, len(m.data))
+	for _, t := range m.data {
+		todos = append(todos, t)
+	}
+	return todos, nil
+}
+
+func (m *MemoryRepository) Update(todo *domain.Todo) error {
+	if _, ok := m.data[todo.ID]; !ok {
+		return domain.ErrNotFound
+	}
+	m.data[todo.ID] = todo
+	return nil
+}
+
+func (m *MemoryRepository) Delete(id int64) error {
+	delete(m.data, id)
+	return nil
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/example/todo/internal/domain"
+	"github.com/example/todo/internal/repository"
+)
+
+func TestTodoService(t *testing.T) {
+	repo := repository.NewMemoryRepository()
+	svc := NewTodoService(repo)
+
+	todo := &domain.Todo{Title: "test"}
+	if err := svc.Create(todo); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if todo.ID == 0 {
+		t.Fatalf("expected ID set")
+	}
+
+	got, err := svc.Get(todo.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Title != todo.Title {
+		t.Fatalf("got %q want %q", got.Title, todo.Title)
+	}
+
+	todo.Title = "changed"
+	if err := svc.Update(todo); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	list, err := svc.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected list length 1 got %d", len(list))
+	}
+
+	if err := svc.Delete(todo.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	list, _ = svc.List()
+	if len(list) != 0 {
+		t.Fatalf("expected empty list")
+	}
+}

--- a/internal/service/todo_service.go
+++ b/internal/service/todo_service.go
@@ -1,0 +1,33 @@
+package service
+
+import "github.com/example/todo/internal/domain"
+
+// TodoService provides Todo use cases.
+type TodoService struct {
+	Repo domain.TodoRepository
+}
+
+// NewTodoService creates a new TodoService.
+func NewTodoService(r domain.TodoRepository) *TodoService {
+	return &TodoService{Repo: r}
+}
+
+func (s *TodoService) Create(todo *domain.Todo) error {
+	return s.Repo.Create(todo)
+}
+
+func (s *TodoService) Get(id int64) (*domain.Todo, error) {
+	return s.Repo.Get(id)
+}
+
+func (s *TodoService) List() ([]*domain.Todo, error) {
+	return s.Repo.List()
+}
+
+func (s *TodoService) Update(todo *domain.Todo) error {
+	return s.Repo.Update(todo)
+}
+
+func (s *TodoService) Delete(id int64) error {
+	return s.Repo.Delete(id)
+}


### PR DESCRIPTION
## Summary
- add hexagonal todo list application with bun
- implement in-memory and SQLite repositories
- provide minimal HTTP server
- include simple tests
- update README

## Testing
- `go mod tidy` *(fails: module downloads forbidden)*
- `go vet ./...` *(fails: no required module provides package bun)*
- `go test ./...` *(fails: no required module provides package bun)*

------
https://chatgpt.com/codex/tasks/task_b_68414a61bba08325b770ef0df52f0f34